### PR TITLE
⚠️  Use net.datafaker instead of com.github.javafaker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,9 +206,9 @@
             <version>1.7.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github.javafaker</groupId>
-            <artifactId>javafaker</artifactId>
-            <version>1.0.2</version>
+            <groupId>net.datafaker</groupId>
+            <artifactId>datafaker</artifactId>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/swiss/fihlon/apus/plugin/event/demo/DemoPlugin.java
+++ b/src/main/java/swiss/fihlon/apus/plugin/event/demo/DemoPlugin.java
@@ -17,7 +17,7 @@
  */
 package swiss.fihlon.apus.plugin.event.demo;
 
-import com.github.javafaker.Faker;
+import net.datafaker.Faker;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
 import swiss.fihlon.apus.configuration.Configuration;


### PR DESCRIPTION
Use alternate data faker API as the existing library is no longer maintained and contains a couple of CVE issues.