### PR TITLE
Run nightly build only if repository has changes

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -8,27 +8,44 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
+  check-build:
     runs-on: ubuntu-latest
     name: Check latest build
 
     outputs:
-      last_build_sha: ${{ fromJson(steps.check_last_build.outputs.data).workflow_runs[0].head_sha }}
+      last-build-sha: ${{ fromJson(steps.check-last-build.outputs.data).workflow_runs[0].head_sha }}
 
     steps:
       - uses: octokit/request-action@v2.x
-        id: check_last_build
+        id: check-last-build
         with:
           route: GET /repos/${{github.repository}}/actions/workflows/docker-nightly.yml/runs?per_page=1&status=completed
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: "echo Last daily build: ${{ fromJson(steps.check_last_build.outputs.data).workflow_runs[0].head_sha }}"
+      - run: "echo Last daily build: ${{ fromJson(steps.check-last-build.outputs.data).workflow_runs[0].head_sha }}"
+
+  check-secrets:
+    runs-on: ubuntu-latest
+    name: Check secrets
+
+    outputs:
+      defined: ${{ steps.check-dockerhub-secrets.outputs.defined }}
+
+    steps:
+      - id: check-dockerhub-secrets
+        shell: bash
+        run: |
+          if [[ "${{ secrets.DOCKERHUB_USERNAME }}" != '' &&  "${{ secrets.DOCKERHUB_TOKEN }}" ]]; then
+            echo "defined=true" >> $GITHUB_OUTPUT;
+          else
+            echo "defined=false" >> $GITHUB_OUTPUT;
+          fi
 
   docker:
-    if: needs.check.outputs.last_build_sha != github.sha
+    if: needs.check-build.outputs.last-build-sha != github.sha && needs.check-secrets.outputs.defined == 'true'
     runs-on: ubuntu-latest
     name: Build and push Docker image
-    needs: check
+    needs: [check-build, check-secrets]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ github.actor }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -48,6 +48,6 @@ jobs:
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ github.actor }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
           repository: ${{ github.actor }}/apus

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -44,10 +44,10 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ github.actor }}/apus:nightly
+          tags: ${{ github.repository }}:nightly
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ github.actor }}/apus
+          repository: ${{ github.repository }}

--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -8,43 +8,35 @@ on:
   workflow_dispatch:
 
 jobs:
-  check_date:
-    if: github.repository_owner == 'McPringle'
+  check:
     runs-on: ubuntu-latest
-    name: Check latest commit
+    name: Check latest build
+
     outputs:
-      should_run: ${{ steps.should_run.outputs.should_run }}
+      last_build_sha: ${{ fromJson(steps.check_last_build.outputs.data).workflow_runs[0].head_sha }}
+
     steps:
-      - uses: actions/checkout@v4
-      - name: print latest_commit
-        run: echo ${{ github.sha }}
-      - id: should_run
-        continue-on-error: true
-        name: check latest commit is less than a day
-        run: |
-          sha=$(git rev-list --after="24 hours" ${{ github.sha }})
-          if test -z $sha
-          then
-            echo "should_run=false" >> $GITHUB_OUTPUT
-          else
-            echo "should_run=true" >> $GITHUB_OUTPUT
-          fi
+      - uses: octokit/request-action@v2.x
+        id: check_last_build
+        with:
+          route: GET /repos/${{github.repository}}/actions/workflows/docker-nightly.yml/runs?per_page=1&status=completed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: "echo Last daily build: ${{ fromJson(steps.check_last_build.outputs.data).workflow_runs[0].head_sha }}"
+
   docker:
-    needs: check_date
-    if: ${{ needs.check_date.outputs.should_run != 'false' }}
+    if: needs.check.outputs.last_build_sha != github.sha
     runs-on: ubuntu-latest
-    name: Docker Nightly
+    name: Build and push Docker image
+    needs: check
+
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Check for changes
-        continue-on-error: true
-        shell: bash
-        run: 'test -n "$(git reflog main --since="24 hours")"'
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -52,10 +44,10 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: mcpringle/apus:nightly
+          tags: ${{ github.actor }}/apus:nightly
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ github.actor }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: mcpringle/apus
+          repository: ${{ github.actor }}/apus


### PR DESCRIPTION
This is a rework from the solution https://github.com/McPringle/apus/pull/110, and it's better.

It solves a lot of problems which can occur based on the Git commits, see this comment on Stack Overflow https://stackoverflow.com/a/76596449/7262345

Furthermore, I've removed your hard-coded username, as I want also be able to run the workflow on the fork. I've tried it out and I was able to build and push to DockerHub and also verify, that these changes should work.

Try it out! 🚀 I'm happy to hear your feedback.

Furthermore, it's enough to add a secret for the `secrets.DOCKERHUB_TOKEN`. If the GitHub and Docker username is the same, we don't need to define it as a secret.

If you want to have it dynamically, why you then hard-code the tag and repository? In case we need that, I would suggest making the whole thing dynamically and add multiple environment variables in a new PR, so that tags, repository, username, repository owner check.